### PR TITLE
added subscriber count for viewing on profile only

### DIFF
--- a/rareserverapi/models/member.py
+++ b/rareserverapi/models/member.py
@@ -11,3 +11,11 @@ class Member(models.Model):
     def full_name(self):
         return f'{self.user.first_name} {self.user.last_name}'
 
+    @property
+    def num_of_subscribers(self):
+        return self.__num_of_subscribers
+
+    @num_of_subscribers.setter
+    def num_of_subscribers(self, value):
+        self.__num_of_subscribers = value
+

--- a/rareserverapi/views/profile_view.py
+++ b/rareserverapi/views/profile_view.py
@@ -3,7 +3,7 @@ from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
 from rest_framework import serializers, status
 from operator import itemgetter
-from rareserverapi.models import Member
+from rareserverapi.models import Member, Subscription
 from django.contrib.auth.models import User
 from django.db.models import Q
 
@@ -20,6 +20,9 @@ class ProfileView(ViewSet):
     def retrieve(self, request, pk):
 
         profile = Member.objects.get(pk=pk)
+        if profile.id == request.auth.user_id:
+            count_subscriptions = Subscription.objects.filter(author_id=request.auth.user_id).count()
+            profile.num_of_subscribers = count_subscriptions
         serialized = ProfileSerializer(profile, context={'request': request})
         return Response(serialized.data, status=status.HTTP_200_OK)
 
@@ -69,4 +72,5 @@ class ProfileSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Member
-        fields = ('id', 'bio', 'profile_image_url', 'user', 'full_name', )
+        fields = ('id', 'bio', 'profile_image_url', 'user',
+             'full_name', 'num_of_subscribers' )


### PR DESCRIPTION

## Show Subscriber Count on User Profile
https://github.com/orgs/NSS-Day-Cohort-58/projects/35/views/1

## Description

Added a subscriber count when the user is looking at their own profile.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

To test this branch:
  - Git fetch --all
  - Git checkout nm-sub-count
  - ./seed_database.sh
  - set Authorization to Token 06787add96eb3264080015997720cb0877b40f90
  - [ ] Test A - Test in Postman by making a GET request to 
    http://localhost:8000/profiles/1 ; You should see property 
    "num_of_subscribers": 2
  - [ ] Test B - Make a GET request to http://localhost:8000/profiles/2 ; you 
     should not see a "num_of_subscribers" property listed.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
